### PR TITLE
Fix checkstyle.xml to work with recent versions of Checkstyle

### DIFF
--- a/code-quality/checkstyle.xml
+++ b/code-quality/checkstyle.xml
@@ -65,6 +65,11 @@
 
     <module name="SuppressWarningsFilter" />
 
+    <module name="LineLength">
+        <property name="max" value="130"/>
+        <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+    </module>
+
     <module name="TreeWalker">
 
         <module name="SuppressWarningsHolder" />
@@ -98,10 +103,7 @@
 
         <!-- Checks for Size Violations.                    -->
         <!-- See http://checkstyle.sf.net/config_sizes.html -->
-        <module name="LineLength">
-            <property name="max" value="130"/>
-            <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
-        </module>
+
         <module name="MethodLength"/>
         <module name="ParameterNumber">
         </module>


### PR DESCRIPTION
Since v8.24 Checkstyle `LineLength` has to be direct descendant of `Checker`. See [this issue](https://github.com/checkstyle/checkstyle/issues/2116).